### PR TITLE
EPS systemd startup unit

### DIFF
--- a/contrib/electrumpersonalserver.service
+++ b/contrib/electrumpersonalserver.service
@@ -7,7 +7,7 @@ After=bitcoind.service
 Requires=bitcoind.service
 
 [Service]
-ExecStart=/your-installation-path/server.py  [optional arguments]
+ExecStart=/your-installation-path/server.py /your-workding-dir [optional arguments]
 User=bitcoin
 Group=bitcoin
 Type=simple

--- a/contrib/electrumpersonalserver.service
+++ b/contrib/electrumpersonalserver.service
@@ -4,16 +4,16 @@
 [Unit]
 Description=Electrum Personal Server
 After=bitcoind.service
+Requires=bitcoind.service
 
 [Service]
-ExecStart=/usr/bin/python3 /your-installation-path/server.py  [optional arguments]
+ExecStart=/your-installation-path/server.py  [optional arguments]
 User=bitcoin
 Group=bitcoin
 Type=simple
 Restart=on-failure
 RestartSec=60
 KillMode=process
-TimeoutSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/electrumpersonalserver.service
+++ b/contrib/electrumpersonalserver.service
@@ -1,0 +1,19 @@
+# Electrum Personal Server: systemd unit
+# /etc/systemd/system/electrumpersonalserver.service
+
+[Unit]
+Description=Electrum Personal Server
+After=bitcoind.service
+
+[Service]
+ExecStart=/usr/bin/python3 /your-installation-path/server.py  [optional arguments]
+User=bitcoin
+Group=bitcoin
+Type=simple
+Restart=on-failure
+RestartSec=60
+KillMode=process
+TimeoutSec=60
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This systemd unit is not ready to run but can serve as a template. It's tested on Ubuntu 16.04 and Raspbian Stretch, but should be pretty universal if systemd is in use.

Not sure how you want to handle the unknown stuff like binary location of python, eps and options.