### PR TITLE
Change localhost to 127.0.0.1 in config sample

### DIFF
--- a/config.cfg_sample
+++ b/config.cfg_sample
@@ -20,7 +20,7 @@
 #my_test_addresses = 3Hh7QujVLqz11tiQsnUE5CSL16WEHBmiyR 1PXRLo1FQoZyF1Jhnz4qbG5x8Bo3pFpybz bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq
 
 [bitcoin-rpc]
-host = localhost
+host = 127.0.0.1
 port = 8332
 #empty means look in the default location
 datadir = 


### PR DESCRIPTION
localhost translation works terribly on Windows. Changing the sample config file to directly point to 127.0.0.1.

The translation can take long time on windows (even a second), for some reason. Since electrum has timeouts on communication with server, this makes EPS unusable. 

Example issues with this:
https://stackoverflow.com/questions/13248260/localhost-taking-too-long-what-to-do
https://serverfault.com/questions/66347/why-is-the-response-on-localhost-so-slow

