### PR TITLE
Tor hidden service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ line with: `ssh username@host -L 50002:localhost:50002` or with [Putty](https://
 for Windows. Then connect Electrum to localhost, and SSH will forward that
 connection to the server.
 
+Electrum Personal Server is now capable of creating an ephemeral Tor
+hidden service so that you may access it remotely.  You can find
+specific instructions [here](doc/tor.md).
+
 #### How is this different from other Electrum servers ?
 
 They are different approaches with different tradeoffs. Electrum Personal

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -1,0 +1,79 @@
+# Accessing Electrum Personal Server remotely
+
+While it is possible to allow access to Electrum Personal Server
+remotely, it may compromise your privacy if done without
+consideration.  For more details on the risks, see: [Using Electrum
+Personal Server and Electrum with a
+smartphone](https://github.com/chris-belcher/electrum-personal-server/issues/36).
+
+A solution to this problem would be accessing Electrum Personal Server
+over Tor.  There are two kinds of hidden services supported by Tor:
+version 2, and version 3.  While a version 2 hidden service is not
+entirely private, it is possible to set it up with basic
+authentication, allowing you to limit access to the onion address.  A
+version 3 hidden service on the other hand, is entirely private.
+Unless you share the onion address of your hidden service publicly,
+your privacy won't be violated.
+
+# Accessing Electrum Personal service as a Tor Hidden Service
+
+At present there are two ways to configure a hidden service,
+1. by editing the `torrc` of your Tor installation, and
+2. by creating an ephemeral hidden service.
+While (1) allows you to configure both kinds of hidden services, only
+version 2 ephemeral hidden services are supported at the moment.
+
+## Configuring a Tor Hidden Service with `torrc`
+
+You can setup a version 3 hidden service with the following lines in
+your `torrc`.
+
+    HiddenServiceDir /var/lib/tor/eps_hsv/
+    HiddenServiceVersion 3
+    HiddenServicePort 50002 127.0.0.1:50002
+
+A version 3 onion address is private by default, so it is sufficient
+keep the onion address secret.  You can find the address in the file
+`/var/lib/tor/eps_hsv/hostname`.
+
+## Configuring an Ephemeral Tor Hidden Service
+
+The other option is to start an ephemeral, version 2, hidden service
+with basic authentication.  The `electrum-personal-server` script
+supports this method.  It also saves the private keys so that on
+subsequent runs the hidden service can be restarted with the same
+onion address and authentication credentials.
+
+On first run, start as:
+
+    $ electrum-personal-server -c /path/to/config.cfg -t
+
+If a hidden service is started successfully, a new configuration file
+with the hidden service configuration is written out to
+`/path/to/config.cfg_updated`.  A new configuration file is written
+out as updating the original would lose any comments that are present.
+The script also logs the onion address and the authentication
+credentials to standard error and the log file by default; reducing
+verbosity (increasing the log level), suppresses this output.  You can
+merge the configuration files before restarting the script to start
+the same hidden service again.
+
+To use this option, you need to install the Tor Python bindings.  You
+can either use your system's package manager, e.g. on Fedora
+
+    $ sudo dnf install python3-stem
+
+You could also use pip to install `stem`:
+
+    $ pip3 install --user stem
+
+As Tor is an optional feature, it is not installed as a dependency
+during the initial installation process.
+
+# Client side configuration
+
+For a version 3 hidden service, there is no need for special
+configuration on the client side.  For a version 2 service with basic
+authentication, you need to add the onion address and the
+authentication credentials when starting Tor.  In case of Orbot, you
+may do this in the "Hidden Services" menu under "Client cookies".

--- a/electrumpersonalserver/server/common.py
+++ b/electrumpersonalserver/server/common.py
@@ -10,7 +10,7 @@ import electrumpersonalserver.server.hashes as hashes
 import electrumpersonalserver.server.merkleproof as merkleproof
 import electrumpersonalserver.server.deterministicwallet as deterministicwallet
 import electrumpersonalserver.server.transactionmonitor as transactionmonitor
-from electrumpersonalserver.server.tor  import start_tor_hidden_service
+from electrumpersonalserver.server.tor import start_tor_hidden_service, hs_store
 
 SERVER_VERSION_NUMBER = "0.1.6"
 
@@ -702,8 +702,10 @@ def main():
         poll_interval_connected = int(config.get("bitcoin-rpc",
             "poll_interval_connected"))
         if config.has_section('tor-hidden-service') or opts.torfirstrun:
-            # TODO: if opts.torfirstrun: save privkey and auth creds
             ctrlr, hsv = start_tor_hidden_service(config, opts.torfirstrun)
+            # test for `hsv` to check if tor hidden service is running
+            if opts.torfirstrun and hsv:
+                hs_store(hsv, config, opts.conf)
         else:
             ctrlr, hsv = None, None
         certfile, keyfile = get_certs(config)

--- a/electrumpersonalserver/server/tor.py
+++ b/electrumpersonalserver/server/tor.py
@@ -58,14 +58,26 @@ def hs_restore(config):
     return res
 
 
-def hs_store(key, store):
+def hs_store(hsv, config, filename):
     """Save the private key and authentication credentials
 
     On first run, the private key and authentication credentials are stored in
     a sub pickle file on disk.  `store` is the path to the pickle file.
 
     """
-    return NotImplemented
+    logger = logging.getLogger('ELECTRUMPERSONALSERVER')
+    config.read_dict({
+        'tor-hidden-service': {
+            # keys should match options in `tor.hs_restore`
+            'private_key_type': hsv.private_key_type,
+            'private_key': hsv.private_key,
+            'auth': hsv.client_auth['bob']
+        }
+    })
+    # writing to a new file to preserve comments in original
+    with open(filename + '_updated', mode='w') as newfile:
+        config.write(newfile)
+        logger.info('writing updated conf: {}'.format(newfile.name))
 
 
 def start_tor_hidden_service(config, firstrun=False):

--- a/electrumpersonalserver/server/tor.py
+++ b/electrumpersonalserver/server/tor.py
@@ -1,0 +1,105 @@
+"""TOR hidden service for Electrum Personal Server
+
+@author Suvayu Ali
+@date   2018-08-04
+
+"""
+
+import os
+import logging
+from configparser import ConfigParser
+from importlib import import_module
+
+def _from_stem_import_cls(module, cls):
+    """Import Tor controller class.
+
+    Since this adds an external dependency, strictly speaking, which is not
+    necessary to use Electrum Personal Server, a failure to import `stem` is
+    not a terminal failure.  Instead, report an error with instructions for
+    solving the issue.
+
+    This means the caller should check if the returned object `is not None`.
+
+    """
+    logger = logging.getLogger('ELECTRUMPERSONALSERVER')
+    try:
+        cls = getattr(import_module(module), cls)
+    except ImportError as err:
+        logger.debug('could not import from `stem`', exc_info=True)
+        logger.error('please install the `stem` package for Tor support')
+    else:
+        return cls
+
+
+def hs_options(overrides=[]):
+    """Default ephemeral hidden service options
+
+    Options can be overridden by passing an override dictionary.
+
+    """
+    opts = {
+        'key_type': 'NEW',
+        'key_content': 'BEST',
+        'discard_key': False,
+        'await_publication': True,
+        'basic_auth': {'bob': None},
+    }
+    opts.update(overrides)
+    return opts.copy()
+
+
+def hs_restore(config):
+    """Restore the private key and authentication credentials from config."""
+    res = {
+        'key_type': config.get('tor-hidden-service', 'private_key_type'),
+        'key_content': config.get('tor-hidden-service', 'private_key'),
+        'basic_auth': {'bob': config.get('tor-hidden-service', 'auth')}
+    }
+    return res
+
+
+def hs_store(key, store):
+    """Save the private key and authentication credentials
+
+    On first run, the private key and authentication credentials are stored in
+    a sub pickle file on disk.  `store` is the path to the pickle file.
+
+    """
+    return NotImplemented
+
+
+def start_tor_hidden_service(config, firstrun=False):
+    logger = logging.getLogger('ELECTRUMPERSONALSERVER')
+    Controller = _from_stem_import_cls(module='stem.control', cls='Controller')
+    if Controller is None:
+        logger.error('Tor hidden service not started')
+        return None, None
+    else:
+        version = _from_stem_import_cls(module='stem', cls='__version__')
+        majv, minv = version.split('.', 3)[:2]
+        ControlError = _from_stem_import_cls(module='stem', cls='ControlError')
+        if majv >= 1 and minv >= 7:  # new in 1.7
+            Timeout = _from_stem_import_cls(module='stem', cls='Timeout')
+            errs = (ControlError, Timeout)
+        else:
+            errs = ControlError
+
+    # TODO: check if tor is running
+    with Controller.from_port(port=9051) as ctrlr:
+        # TODO: multiple authentication methods
+        ctrlr.authenticate()
+
+        opts = hs_options([] if firstrun else hs_restore(config))
+        try:
+            hsv = ctrlr.create_ephemeral_hidden_service(50002, **opts)
+        except errs as err:
+            logger.debug('', exc_info=True)
+            logger.info('could not create hidden service, cleaning up')
+            ctrlr.close()
+            return None, None
+        else:
+            logger.info('hidden service onion: {}.onion'.format(hsv.service_id))
+            # ADD_ONION response does not include auth when provided in options
+            logger.info('hidden service auth: {}'.format(
+                hsv.client_auth.get('bob', opts['basic_auth'].get('bob'))))
+            return ctrlr, hsv

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={"electrumpersonalserver": ["certs/*"]},
     data_files=[
         ("etc/electrum-personal-server", ["config.cfg_sample"]),
-        ("share/doc/electrum-personal-server", ["README.md"]),
+        ("share/doc/electrum-personal-server", ["README.md", "doc/tor.md"]),
     ],
     install_requires=[
         'wheel'


### PR DESCRIPTION
This PR implements the idea discussed in #36.

Here's a summary:
1. Add support for creating a Tor hidden service to make Electrum Personal Server accessible remotely
2. On first run, the private keys are stored in a duplicate config file to reuse

Notes:
- Only version 2 hidden services are supported at the moment
- Tor Python bindings (`stem`) are not installed when using `pip`.  This is deliberate because creating a hidden service is an optional feature.
- Usage instructions are documented in: `doc/tor.md`

I have only tested this lightly, so please try out as many things as you can think of.