### PR TITLE
Do not install sample config along with docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include README.md
 include doc/*.md
 include electrumpersonalserver/certs/*
-include config.cfg_sample

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ on [full nodes](https://en.bitcoin.it/wiki/Full_node).
   `--server localhost:50002:s`.
 
 * Download the [latest release](https://github.com/chris-belcher/electrum-personal-server/releases)
-  of Electrum Personal Server. Enter the directory and rename the file
+  of Electrum Personal Server. Enter the directory and copy the file
   `config.cfg_sample` to `config.cfg`.
 
 * Edit the file `config.cfg` to configure everything about the server. Add your
@@ -62,7 +62,7 @@ on [full nodes](https://en.bitcoin.it/wiki/Full_node).
   in the Electrum client menu `Wallet` -> `Information`.  You can add multiple
   master public keys or watch-only addresses by adding separate lines for the
   different keys/addresses:
-  
+
       wallet1 = xpub661MyMwAqRbcF...
       wallet2 = xpub7712KLsfsg46G...
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     },
     package_data={"electrumpersonalserver": ["certs/*"]},
     data_files=[
-        ("etc/electrum-personal-server", ["config.cfg_sample"]),
         ("share/doc/electrum-personal-server", ["README.md"]),
     ],
     install_requires=[


### PR DESCRIPTION
As can be seen in #87, renaming the sample config and editing seems common behaviour (the README also recommends this), so maybe it's better to not install the sample config along with the docs.

While this might seem harmless (and obvious), this could cause problems when updating.  Since users are installing from the repo, to update they will probably try to do `git pull` and run into conflicts.  So maybe along with this change, the docs also need to update the advice from "rename and edit" to "copy and edit".