### PR TITLE
check for first 3 addresses and last address

### DIFF
--- a/electrumpersonalserver/server/common.py
+++ b/electrumpersonalserver/server/common.py
@@ -546,7 +546,9 @@ def get_scriptpubkeys_to_monitor(rpc, config):
         first_addrs = [hashes.script_to_address(s, rpc) for s in first_spks]
         logger.info("\n" + config_mpk_key + " =>\n\t" + "\n\t".join(
             first_addrs))
-        if not set(first_addrs).issubset(imported_addresses):
+        last_spk = wal.get_scriptpubkeys(0, int(config.get("bitcoin-rpc", "initial_import_count")) - 1, 1) 
+        last_addr = [hashes.script_to_address(last_spk[0], rpc)] 
+        if not set(first_addrs + last_addr).issubset(imported_addresses):
             import_needed = True
             wallets_imported += 1
             for change in [0, 1]:


### PR DESCRIPTION
One solution I see to the problem discussed in #115 : beside checking for the 3 first addresses in the list, we also check the last address that should be imported according to the `initial_import_count` parameter. If the 4 addresses are not in `imported_addresses`, then `import_needed` is set to `True`.

I'm trying to write a test for that so I'm not sure it works or not.