### PR TITLE
add createwallet disable_private_key=true in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ on [full nodes](https://en.bitcoin.it/wiki/Full_node).
   [verify the digital signatures](https://bitcoin.stackexchange.com/questions/50185/how-to-verify-bitcoin-core-release-signing-keys)
   of any binaries before running them, or compile from source. The Bitcoin node
   must have wallet enabled, and must have the RPC server switched on (`server=1`
-  in bitcoin.conf).
+  in bitcoin.conf). On first run, it is recommended to create a wallet dedicated to Electrum Personal 	Server using the command line argument `bitcoin-cli createwallet EPS true`.
 
 * If you dont already have it, download and install
   [Electrum bitcoin wallet](https://electrum.org/), and set up your Electrum
@@ -66,6 +66,10 @@ on [full nodes](https://en.bitcoin.it/wiki/Full_node).
 
       wallet1 = xpub661MyMwAqRbcF...
       wallet2 = xpub7712KLsfsg46G...
+
+* If you created a wallet dedicated to Electrum Personal Server in Bitcoin Core,
+  you have to modify the line `wallet_filename` in the `[bitcoin-rpc]` section 
+  with the name of the  wallet, for example `EPS`.
 
 * If using the windows packaged binary release, drag the file `config.ini` onto
   the file `electrum-personal-server.exe` to run the server, or on the command


### PR DESCRIPTION
Following issues #115 where I needed to delete a wallet in order to import addresses again, I noticed it has already been suggested to create a wallet on Bitcoin Core dedicated to Electrum Personal Server in #21 and #41. 
There were in fact 2 suggestions in #21 :
* the first one was to add the `createwallet` command in README
* the second was to check if the `disable_private_keys` file was enabled in Bitcoin Core wallet and prevent user to use it if it is not the case
I suggest first relevant modification in the README file. I don't know if it is necessary to totally block user from using a "hot" wallet, so I leave it as "it is recommended..." for now, and we'll see later if this need to change.