### PR TITLE
Add quick-start installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ on [full nodes](https://en.bitcoin.it/wiki/Full_node).
 
 ## How To
 
+#### Quick start on a Debian/Ubuntu machine with a running Bitcoin full or pruned node
+1. Download the [latest release](https://github.com/chris-belcher/electrum-personal-server/releases) of Electrum Personal Server. (Not the Windows version, the "Source code" zip or tar.gz.) 
+1. Extract the compressed file
+1. Enter the directory
+1. `cp config.ini_sample config.ini`
+1. Edit the config.ini file:
+    1. Add bitcoind back-end RPC auth information
+    1. Add wallet master public keys for your wallets
+1. Install the server to your home directory with `pip3 install --user .`
+1. Make sure `~/local/bin` is in your $PATH (`echo $PATH`). If not, add it:
+   `echo 'PATH=$HOME/.local/bin:$PATH' >> ~/.profile`, logout, and log in again
+1. Run the server: `electrum-personal-server config.ini`
+1. Start your Electrum wallet: `electrum --oneserver --server localhost:50002:s`.
+
+#### Installation notes
+
 * If you dont already have them, download and install Bitcoin Core version 0.17
   or higher. Make sure you
   [verify the digital signatures](https://bitcoin.stackexchange.com/questions/50185/how-to-verify-bitcoin-core-release-signing-keys)

--- a/electrumpersonalserver/server/common.py
+++ b/electrumpersonalserver/server/common.py
@@ -158,7 +158,7 @@ def handle_query(sock, line, rpc, txmonitor, disable_mempool_fee_histogram,
                 reply = {"block_height": txheader["block_height"], "pos":
                     electrum_proof["pos"], "merkle": electrum_proof["merkle"]}
             except (ValueError, JsonRpcError) as e:
-                logger.notice("merkle proof not found for " + txid + " sending"
+                logger.info("merkle proof not found for " + txid + " sending"
                     + " a dummy, Electrum client should be run with "
                     + "--skipmerklecheck")
                 #reply with a proof that the client with accept if


### PR DESCRIPTION
The current README.md provides detailed and thorough instructions for getting started, interspersed with various considerations that are confusing for someone who just wants to try EPS. This adds a "quick start" block to the README which concisely explains what needs to be done in a common situation (adding EPS to a Debian/Ubuntu based full node).