### PR TITLE
Set loglevel for SSL cert selection from to info

### DIFF
--- a/electrumpersonalserver/server/common.py
+++ b/electrumpersonalserver/server/common.py
@@ -292,7 +292,7 @@ def get_certs(config):
         certfile = resource_filename('electrumpersonalserver', __certfile__)
         keyfile = resource_filename('electrumpersonalserver', __keyfile__)
         if os.path.exists(certfile) and os.path.exists(keyfile):
-            logger.debug('using cert: {}, key: {}'.format(certfile, keyfile))
+            logger.info('using cert: {}, key: {}'.format(certfile, keyfile))
             return certfile, keyfile
         else:
             raise ValueError('invalid cert: {}, key: {}'.format(


### PR DESCRIPTION
This was logging to debug before, which made it hard to detect an issue
when using docker container selected the wrong certificate, despite otherwise configured:

/usr/local/lib/python3.7/site-packages/electrumpersonalserver/certs/cert.crt

without being able to see this via `docker log`.

Since this an interesting and onetime log entry I recommend using loglevel info for this.