### PR TITLE
Handle uncaught exception when electrum connects

### DIFF
--- a/electrumpersonalserver/server/common.py
+++ b/electrumpersonalserver/server/common.py
@@ -123,7 +123,7 @@ def run_electrum_server(rpc, txmonitor, config):
             except socket.timeout:
                 is_node_reachable = on_heartbeat_listening(txmonitor)
                 accepting_clients = is_node_reachable
-            except (ConnectionRefusedError, ssl.SSLError):
+            except (ConnectionRefusedError, ssl.SSLError, IOError):
                 sock.close()
                 sock = None
         logger.debug('Electrum connected from ' + str(addr[0]))


### PR DESCRIPTION
IOError raised from `ssl.wrap_socket` was causing eps 0.2.1 to crash when electrum wallet attempted to connect.  Quietly catch the IOError and handle the same way as other connection errors so that eps keeps listening for a connection.

Fixes #198, fixes #197.