### PR TITLE
Update transactionmonitor.py

### DIFF
--- a/electrumpersonalserver/server/transactionmonitor.py
+++ b/electrumpersonalserver/server/transactionmonitor.py
@@ -155,7 +155,7 @@ class TransactionMonitor(object):
                         logger.error("Not enough addresses imported.")
                         logger.error("Delete wallet.dat and increase the value"
                             + " of `initial_import_count` in the file"
-                            + " `config.cfg` then reimport and rescan")
+                            + " `config.ini` then reimport and rescan")
                         #TODO make it so users dont have to delete wallet.dat
                         # check whether all initial_import_count addresses are
                         # imported rather than just the first one


### PR DESCRIPTION
Minor detail, the eps config file is called config.ini, not config.cfg
There could be other improvements made to this error message, such as specifying that this refers to the bitcoind wallet.dat, but eps config.ini