### PR TITLE
Python setup tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     },
     package_data={"electrumpersonalserver": ["certs/*"]},
     data_files=[
-        ("share/doc/electrum-personal-server", ["README.md"]),
+        ("share/doc/electrum-personal-server", ["README.md",
+                                                "config.ini_sample"]),
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="electrum-personal-server",
-    version="0.2.0.dev0",
+    version="0.2.1.1",
     description="Electrum Personal Server",
     author="Chris Belcher",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
     license="MIT",
     include_package_data=True,
     packages=find_packages(exclude=["tests"]),
-    setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
@@ -19,7 +18,4 @@ setup(
     data_files=[
         ("share/doc/electrum-personal-server", ["README.md"]),
     ],
-    install_requires=[
-        'wheel'
-    ]
 )


### PR DESCRIPTION
Commit b52450e43be8f57c3e8c6513b6ae279cde2aeafd simply updates the version in `setup.py` to reflect the latest git tag.

Commit 8fe7773d294afcf2d24cbfb6576f35b9b7b5663e removes the dependencies on `pytest-runner` and `wheel` to allow more
proper installation by package managers that are sometimes sandboxed (like Gentoo). This improves package manager handling, and does not break the existing `pip3 install --user` mechanism. The resulting installed files are the same.

Commit 9d61238f9ecb2c045c00125665fadc570a49cdc0 installs the config.ini example into share/doc along with the README. I again consider this useful for package managers, since it's an essential file, but doesn't get installed as data.