### PR TITLE
listunspent and import_addresses API methods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python
+WORKDIR /
+RUN git clone https://github.com/commerceblock/electrum-personal-server.git
+WORKDIR /electrum-personal-server
+ADD config.ini config.ini
+RUN pip3 install .
+CMD ["electrum-personal-server", "config.ini"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Forked from https://github.com/chris-belcher/electrum-personal-server
+
 # Electrum Personal Server
 
 Electrum Personal Server aims to make using Electrum bitcoin wallet more secure

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Forked from https://github.com/chris-belcher/electrum-personal-server
-
 # Electrum Personal Server
 
 Electrum Personal Server aims to make using Electrum bitcoin wallet more secure

--- a/electrumpersonalserver/server/common.py
+++ b/electrumpersonalserver/server/common.py
@@ -303,7 +303,6 @@ def get_scriptpubkeys_to_monitor(rpc, config):
                     break
                 spks_to_monitor.append(spks[0])
             wal.rewind_one(change)
-
     spks_to_monitor.extend([hashes.address_to_script(addr, rpc)
         for addr in watch_only_addresses])
     et = time.time()

--- a/electrumpersonalserver/server/electrumprotocol.py
+++ b/electrumpersonalserver/server/electrumprotocol.py
@@ -256,6 +256,14 @@ class ElectrumProtocol(object):
                     + "hash(address) = " + scrhash)
                 raise UnknownScripthashError(scrhash)
             self._send_response(query, balance)
+        elif method == "blockchain.scripthash.listunspent":
+            scrhash = query["params"][0]
+            utxos = self.txmonitor.get_address_utxos(scrhash)
+            if utxos == None:
+                self.logger.warning("Address history not known to server, "
+                    + "hash(address) = " + scrhash)
+                raise UnknownScripthashError(scrhash)
+            self._send_response(query, utxos)
         elif method == "server.ping":
             self._send_response(query, None)
         elif method == "blockchain.headers.subscribe":

--- a/electrumpersonalserver/server/electrumprotocol.py
+++ b/electrumpersonalserver/server/electrumprotocol.py
@@ -7,11 +7,13 @@ import struct
 import tempfile
 import socket
 from collections import defaultdict
+from electrumpersonalserver.server.deterministicwallet import import_addresses
 
 from electrumpersonalserver.server.hashes import (
     hash_merkle_root,
     get_status_electrum,
-    bytes_fmt
+    bytes_fmt,
+    address_to_script
 )
 from .jsonrpc import JsonRpc, JsonRpcError
 from electrumpersonalserver.server.peertopeer import tor_broadcast_tx
@@ -392,6 +394,7 @@ class ElectrumProtocol(object):
             self._send_response(query, result)
         elif method == "blockchain.estimatefee":
             estimate = self.rpc.call("estimatesmartfee", [query["params"][0]])
+            self.logger.info('estimate: ' + estimate)
             feerate = 0.0001
             if "feerate" in estimate:
                 feerate = estimate["feerate"]
@@ -483,7 +486,27 @@ class ElectrumProtocol(object):
             except JsonRpcError as e:
                 error = {"message": repr(e)}
                 self._send_error(query["id"], error)
+        elif method == "import_addresses":
+            addresses = query["params"][0]
+            rescan_height = False
+            if len(query["params"]) > 1:
+                rescan_height = query["params"][1]
+            if rescan_height < 0:
+                rescan_height = False
+            if len(addresses) > 0:
+                spks_to_monitor = []
+                spks_to_monitor.extend([address_to_script(addr, self.rpc) for addr in addresses])
+                self.logger.info("Importing addresses:" + ' '.join(map(str,addresses)) +  "...")
+                import_addresses(self.rpc, spks_to_monitor, [], -1, self.logger)
+                self.logger.info("end")
+                if ( rescan_height ):
+                    self.logger.info("Rescanning. . . for progress indicator see the bitcoin node's" + " debug.log file")
+                    self.rpc.call("rescanblockchain", [rescan_height])
+                    self.logger.info("end")
+                self.txmonitor.build_address_history(spks_to_monitor)
+            self._send_response(query, { "result": "success"} )
         else:
+            self.logger.error(method)
             self.logger.error("*** BUG! Not handling method: " + method
                 + " query=" + str(query))
 

--- a/electrumpersonalserver/server/transactionmonitor.py
+++ b/electrumpersonalserver/server/transactionmonitor.py
@@ -111,7 +111,7 @@ class TransactionMonitor(object):
     def build_address_history(self, monitored_scriptpubkeys):
         logger = self.logger
         logger.info("Building history with " +
-            str(len(monitored_scriptpubkeys)) + " addresses . . . : ")
+            str(len(monitored_scriptpubkeys)) + " addresses . . .")
         st = time.time()
         address_history = {}
         for spk in monitored_scriptpubkeys:

--- a/electrumpersonalserver/server/transactionmonitor.py
+++ b/electrumpersonalserver/server/transactionmonitor.py
@@ -111,7 +111,7 @@ class TransactionMonitor(object):
     def build_address_history(self, monitored_scriptpubkeys):
         logger = self.logger
         logger.info("Building history with " +
-            str(len(monitored_scriptpubkeys)) + " addresses . . .")
+            str(len(monitored_scriptpubkeys)) + " addresses . . . : ")
         st = time.time()
         address_history = {}
         for spk in monitored_scriptpubkeys:
@@ -208,8 +208,14 @@ class TransactionMonitor(object):
         et = time.time()
         logger.info("Found " + str(count) + " txes. History built in "
             + str(et - st) + "sec")
-        self.address_history = address_history
-        self.unconfirmed_txes = unconfirmed_txes
+        if(self.address_history == None):
+            self.address_history=address_history
+        else:
+            self.address_history.update(address_history)
+        if(self.unconfirmed_txes == None): 
+            self.unconfirmed_txes=unconfirmed_txes
+        else:
+            self.unconfirmed_txes.update(unconfirmed_txes)
         return True
 
     def get_input_and_output_scriptpubkeys(self, txid):


### PR DESCRIPTION
Add the following API methods:

* blockchain.scripthash.listunspent - returns unspent transaction object information for the given scripthash
* import_addresses - imports the specified addresses and rescans from the specified block_height.