### PR TITLE
Updated Raspibolt link

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ rebroadcasting transactions without tor.
 
 ### Links to other setup guides
 
-- [How to setup Electrum Personal Server on a Raspberry Pi](https://github.com/Stadicus/RaspiBolt/blob/master/raspibolt_64_electrum.md)
+- [How to setup Electrum Personal Server on a Raspberry Pi](https://raspibolt.github.io/raspibolt/raspibolt_64_electrum.html)
 - [Electrum Personal Server on Windows 10](https://driftwoodpalace.github.io/Hodl-Guide/hodl-guide_63_eps-win.html)
 - [Running Electrum Personal Server on Mac OS](https://driftwoodpalace.github.io/Hodl-Guide/hodl-guide_64_eps-mac.html)
 - [How to set up your own Bitcoin node, Electrum wallet and Server](https://curiosityoverflow.xyz/posts/bitcoin-electrum-wallet/)


### PR DESCRIPTION
Hi Chris, 
I am updating the new Stadicus link.

Please see his tweet:
<blockquote class="twitter-tweet"><p lang="en" dir="ltr">I moved the <a href="https://twitter.com/hashtag/RaspiBolt?src=hash&amp;ref_src=twsrc%5Etfw">#RaspiBolt</a> guide into its own GitHub organization, with the goal to make it more future-proof and allow others to contribute more directly.<br><br>Automatic redirects should work, but here&#39;s the updated link anyway :)<a href="https://t.co/4yz1GEpEll">https://t.co/4yz1GEpEll</a></p>&mdash; bitcoin/stadicus (@Stadicus3000) <a href="https://twitter.com/Stadicus3000/status/1454065737543430144?ref_src=twsrc%5Etfw">October 29, 2021</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 

New link:
[Bonus guide: Electrum Personal Server](https://raspibolt.github.io/raspibolt/raspibolt_64_electrum.html)

Thanks @Stadicus and @chris-belcher for your contribution to the present and the future :).