### PR TITLE
Update p2p user agent string to 22

### DIFF
--- a/electrumpersonalserver/server/peertopeer.py
+++ b/electrumpersonalserver/server/peertopeer.py
@@ -18,7 +18,7 @@ from electrumpersonalserver.server.socks import (
 from electrumpersonalserver.server.jsonrpc import JsonRpcError
 
 PROTOCOL_VERSION = 70016
-DEFAULT_USER_AGENT = '/Satoshi:0.21.0/'
+DEFAULT_USER_AGENT = '/Satoshi:0.22.0/'
 
 #https://github.com/bitcoin/bitcoin/blob/master/src/protocol.h
 NODE_NETWORK = 1


### PR DESCRIPTION
Version 22 is now the most popular user agent of listening nodes https://bitnodes.io/nodes/, and trending to be the most popular overall very soon https://luke.dashjr.org/programs/bitcoin/files/charts/software.html.