### PR TITLE
Add signet support

### DIFF
--- a/docs/developer-notes.md
+++ b/docs/developer-notes.md
@@ -40,10 +40,10 @@ reasoning for your decisions. Further explanation
 
 ## Testing
 
-Electrum Personal Server also works on [testnet](https://en.bitcoin.it/wiki/Testnet)
-and [regtest](https://bitcoin.org/en/glossary/regression-test-mode). The
-Electrum wallet can be started in testnet mode with the command line flag
-`--testnet` or `--regtest`.
+Electrum Personal Server also works on [testnet](https://en.bitcoin.it/wiki/Testnet),
+[regtest](https://bitcoin.org/en/glossary/regression-test-mode) and
+[signet](https://en.bitcoin.it/wiki/Signet). The Electrum wallet can be started
+in testnet mode with the command line flag `--testnet`, `--regtest` or `--signet`.
 
 pytest is used for automated testing. On Debian-like systems install with
 `pip3 install pytest pytest-cov`

--- a/electrumpersonalserver/server/deterministicwallet.py
+++ b/electrumpersonalserver/server/deterministicwallet.py
@@ -63,7 +63,7 @@ def is_string_parsable_as_hex_int(s):
 def parse_electrum_master_public_key(keydata, gaplimit, rpc, chain):
     if chain == "main":
         xpub_vbytes = b"\x04\x88\xb2\x1e"
-    elif chain == "test" or chain == "regtest":
+    elif chain == "test" or chain == "regtest" or chain == "signet":
         xpub_vbytes = b"\x04\x35\x87\xcf"
     else:
         assert False


### PR DESCRIPTION
This PR adds [signet](https://en.bitcoin.it/wiki/Signet) support by adding the missing check for setting the xpub serialization version bytes (`xpub_vbytes`), which are the same for all testnets. The developer documentation is also extended accordingly which instructions on how to start Electrum in signet mode. Did some basic tests and everything seems to work fine.