### PR TITLE
Remove unused private key cracking functions

### DIFF
--- a/electrumpersonalserver/bitcoin/main.py
+++ b/electrumpersonalserver/bitcoin/main.py
@@ -317,11 +317,6 @@ def subtract_pubkeys(p1, p2):
             decode_pubkey(p1, f1), (k2[0], (P - k2[1]) % P)), f1)
 
 
-def subtract_privkeys(p1, p2):
-    f1, f2 = get_privkey_format(p1), get_privkey_format(p2)
-    k2 = decode_privkey(p2, f2)
-    return encode_privkey((decode_privkey(p1, f1) - k2) % N, f1)
-
 # Hashes
 
 

--- a/electrumpersonalserver/server/electrumprotocol.py
+++ b/electrumpersonalserver/server/electrumprotocol.py
@@ -22,7 +22,7 @@ from electrumpersonalserver.server.merkleproof import (
 #protocol documentation
 #https://github.com/spesmilo/electrumx/blob/master/docs/protocol-methods.rst
 
-SERVER_VERSION_NUMBER = "0.2.3"
+SERVER_VERSION_NUMBER = "0.2.4"
 
 SERVER_PROTOCOL_VERSION_MAX = 1.4
 SERVER_PROTOCOL_VERSION_MIN = 1.1

--- a/release-notes
+++ b/release-notes
@@ -1,3 +1,10 @@
+# Release v0.2.4 (12th June 2022)
+
+New release, thanks to contributions by andrewtoth
+And thanks to everyone else who contributed via discussion and donations
+
+* Fixed crash caused by deprecated RPC in Bitcoin Core 23.0
+
 # Release v0.2.3 (9th March 2022)
 
 New release, thanks to contributions by andrewtoth and federicociro

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="electrum-personal-server",
-    version="0.2.3",
+    version="0.2.4",
     description="Electrum Personal Server",
     author="Chris Belcher",
     license="MIT",


### PR DESCRIPTION
The function `crack_bip32_privkey` was introduced in the first commit (probably copied over from pybitcoinlib), but was never used, i.e. it can be removed. The PR also removes the function `subtract_privkeys` which was only used in the cracking function. To my understanding, EPS in general shouldn't need to do anything with private keys.