### PR TITLE
Remove unused BIP32 functions (pybitcointools)

### DIFF
--- a/electrumpersonalserver/bitcoin/deterministic.py
+++ b/electrumpersonalserver/bitcoin/deterministic.py
@@ -80,20 +80,6 @@ def bip32_deserialize(data):
     return (vbytes, depth, fingerprint, i, chaincode, key)
 
 
-def raw_bip32_privtopub(rawtuple):
-    vbytes, depth, fingerprint, i, chaincode, key = rawtuple
-    newvbytes = MAINNET_PUBLIC if vbytes == MAINNET_PRIVATE else TESTNET_PUBLIC
-    return (newvbytes, depth, fingerprint, i, chaincode, privtopub(key))
-
-
-def bip32_ckd(data, i):
-    return bip32_serialize(raw_bip32_ckd(bip32_deserialize(data), i))
-
-
-def bip32_extract_key(data):
-    return safe_hexlify(bip32_deserialize(data)[-1])
-
-
 # electrum
 def electrum_stretch(seed):
     return slowsha(seed)

--- a/electrumpersonalserver/bitcoin/deterministic.py
+++ b/electrumpersonalserver/bitcoin/deterministic.py
@@ -86,37 +86,13 @@ def raw_bip32_privtopub(rawtuple):
     return (newvbytes, depth, fingerprint, i, chaincode, privtopub(key))
 
 
-def bip32_privtopub(data):
-    return bip32_serialize(raw_bip32_privtopub(bip32_deserialize(data)))
-
-
 def bip32_ckd(data, i):
     return bip32_serialize(raw_bip32_ckd(bip32_deserialize(data), i))
-
-
-def bip32_master_key(seed, vbytes=MAINNET_PRIVATE):
-    I = hmac.new(
-        from_string_to_bytes("Bitcoin seed"), seed, hashlib.sha512).digest()
-    return bip32_serialize((vbytes, 0, b'\x00' * 4, 0, I[32:], I[:32] + b'\x01'
-                           ))
-
-
-def bip32_bin_extract_key(data):
-    return bip32_deserialize(data)[-1]
 
 
 def bip32_extract_key(data):
     return safe_hexlify(bip32_deserialize(data)[-1])
 
-
-def bip32_descend(*args):
-    if len(args) == 2:
-        key, path = args
-    else:
-        key, path = args[0], map(int, args[1:])
-    for p in path:
-        key = bip32_ckd(key, p)
-    return bip32_extract_key(key)
 
 # electrum
 def electrum_stretch(seed):

--- a/electrumpersonalserver/bitcoin/deterministic.py
+++ b/electrumpersonalserver/bitcoin/deterministic.py
@@ -1,6 +1,4 @@
 from electrumpersonalserver.bitcoin.main import *
-import hmac
-import hashlib
 from binascii import hexlify
 
 # Below code ASSUMES binary inputs and compressed pubkeys
@@ -25,36 +23,6 @@ PUBLIC = [  b'\x04\x88\xb2\x1e', #mainnet p2pkh or p2sh xpub
             b'\x04\x5f\x1c\xf6', #testnet p2wpkh vpub
             b'\x02\x57\x54\x83' #testnet p2wsh Vpub
         ]
-
-# BIP32 child key derivation
-
-def raw_bip32_ckd(rawtuple, i):
-    vbytes, depth, fingerprint, oldi, chaincode, key = rawtuple
-    i = int(i)
-
-    if vbytes in PRIVATE:
-        priv = key
-        pub = privtopub(key)
-    else:
-        pub = key
-
-    if i >= 2**31:
-        if vbytes in PUBLIC:
-            raise ValueError("Can't do private derivation on public key!")
-        I = hmac.new(chaincode, b'\x00' + priv[:32] + encode(i, 256, 4),
-                     hashlib.sha512).digest()
-    else:
-        I = hmac.new(chaincode, pub + encode(i, 256, 4),
-                     hashlib.sha512).digest()
-
-    if vbytes in PRIVATE:
-        newkey = add_privkeys(I[:32] + B'\x01', priv)
-        fingerprint = bin_hash160(privtopub(key))[:4]
-    if vbytes in PUBLIC:
-        newkey = add_pubkeys(compress(privtopub(I[:32])), key)
-        fingerprint = bin_hash160(key)[:4]
-
-    return (vbytes, depth + 1, fingerprint, i, I[32:], newkey)
 
 
 def bip32_serialize(rawtuple):

--- a/electrumpersonalserver/bitcoin/secp256k1_deterministic.py
+++ b/electrumpersonalserver/bitcoin/secp256k1_deterministic.py
@@ -1,6 +1,4 @@
 from electrumpersonalserver.bitcoin.secp256k1_main import *
-import hmac
-import hashlib
 from binascii import hexlify
 
 # Below code ASSUMES binary inputs and compressed pubkeys
@@ -10,36 +8,6 @@ TESTNET_PRIVATE = b'\x04\x35\x83\x94'
 TESTNET_PUBLIC = b'\x04\x35\x87\xCF'
 PRIVATE = [MAINNET_PRIVATE, TESTNET_PRIVATE]
 PUBLIC = [MAINNET_PUBLIC, TESTNET_PUBLIC]
-
-# BIP32 child key derivation
-
-def raw_bip32_ckd(rawtuple, i):
-    vbytes, depth, fingerprint, oldi, chaincode, key = rawtuple
-    i = int(i)
-
-    if vbytes in PRIVATE:
-        priv = key
-        pub = privtopub(key, False)
-    else:
-        pub = key
-
-    if i >= 2**31:
-        if vbytes in PUBLIC:
-            raise Exception("Can't do private derivation on public key!")
-        I = hmac.new(chaincode, b'\x00' + priv[:32] + encode(i, 256, 4),
-                     hashlib.sha512).digest()
-    else:
-        I = hmac.new(chaincode, pub + encode(i, 256, 4),
-                     hashlib.sha512).digest()
-
-    if vbytes in PRIVATE:
-        newkey = add_privkeys(I[:32] + B'\x01', priv, False)
-        fingerprint = bin_hash160(privtopub(key, False))[:4]
-    if vbytes in PUBLIC:
-        newkey = add_pubkeys([privtopub(I[:32] + '\x01', False), key], False)
-        fingerprint = bin_hash160(key)[:4]
-
-    return (vbytes, depth + 1, fingerprint, i, I[32:], newkey)
 
 def bip32_serialize(rawtuple):
     vbytes, depth, fingerprint, i, chaincode, key = rawtuple

--- a/electrumpersonalserver/bitcoin/secp256k1_deterministic.py
+++ b/electrumpersonalserver/bitcoin/secp256k1_deterministic.py
@@ -67,26 +67,8 @@ def raw_bip32_privtopub(rawtuple):
     newvbytes = MAINNET_PUBLIC if vbytes == MAINNET_PRIVATE else TESTNET_PUBLIC
     return (newvbytes, depth, fingerprint, i, chaincode, privtopub(key, False))
 
-def bip32_privtopub(data):
-    return bip32_serialize(raw_bip32_privtopub(bip32_deserialize(data)))
-
 def bip32_ckd(data, i):
     return bip32_serialize(raw_bip32_ckd(bip32_deserialize(data), i))
 
-def bip32_master_key(seed, vbytes=MAINNET_PRIVATE):
-    I = hmac.new(
-        from_string_to_bytes("Bitcoin seed"), seed, hashlib.sha512).digest()
-    return bip32_serialize((vbytes, 0, b'\x00' * 4, 0, I[32:], I[:32] + b'\x01'
-                           ))
-
 def bip32_extract_key(data):
     return safe_hexlify(bip32_deserialize(data)[-1])
-
-def bip32_descend(*args):
-    if len(args) == 2:
-        key, path = args
-    else:
-        key, path = args[0], map(int, args[1:])
-    for p in path:
-        key = bip32_ckd(key, p)
-    return bip32_extract_key(key)

--- a/electrumpersonalserver/bitcoin/secp256k1_deterministic.py
+++ b/electrumpersonalserver/bitcoin/secp256k1_deterministic.py
@@ -61,14 +61,3 @@ def bip32_deserialize(data):
     chaincode = dbin[13:45]
     key = dbin[46:78] + b'\x01' if vbytes in PRIVATE else dbin[45:78]
     return (vbytes, depth, fingerprint, i, chaincode, key)
-
-def raw_bip32_privtopub(rawtuple):
-    vbytes, depth, fingerprint, i, chaincode, key = rawtuple
-    newvbytes = MAINNET_PUBLIC if vbytes == MAINNET_PRIVATE else TESTNET_PUBLIC
-    return (newvbytes, depth, fingerprint, i, chaincode, privtopub(key, False))
-
-def bip32_ckd(data, i):
-    return bip32_serialize(raw_bip32_ckd(bip32_deserialize(data), i))
-
-def bip32_extract_key(data):
-    return safe_hexlify(bip32_deserialize(data)[-1])


### PR DESCRIPTION
This PR is another step towards [getting rid of unused functions from the pybitcointools library](https://github.com/chris-belcher/electrum-personal-server/pull/276#issuecomment-1153907695) which was imported in the first commit. Note that the changes are deliberately kept minimal and are divided up into multiple commit in order to make review trivial; at each commit, searching the removed function in the code-base via executing `git grep funcname` verifies that the function is not directly called anymore (see also commit messages).